### PR TITLE
styling, we can now assign user_ids!!!!

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -17,6 +17,8 @@ class PostsController < ApplicationController
   def create
     @topic = Topic.find params[:topic_id]
     @post = @topic.posts.create post_params
+    @post.user = current_user
+    @post.save
     redirect_to topic_path(@topic)
   end
 
@@ -43,6 +45,8 @@ class PostsController < ApplicationController
     @topic = Topic.find params[:topic_id]
     @post = Post.find params[:id]
     @comment = @post.comments.create comment_params
+    @comment.user = current_user
+    @comment.save
     redirect_to topic_post_path(@topic, @post)
   end
 
@@ -63,6 +67,8 @@ class PostsController < ApplicationController
     params.require(:post).permit(
         :title,
         :content,
+        user_ids: []
+
     )
   end
 end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -9,6 +9,8 @@ class TopicsController < ApplicationController
 
 	def create
 		@topic = Topic.create topic_params
+		@topic.user = current_user
+		@topic.save
 		redirect_to topics_path
 	end	
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,4 @@
 class Comment < ActiveRecord::Base
   belongs_to :commentable, polymorphic: true
+  belongs_to :user
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,5 @@
 class Post < ActiveRecord::Base
   belongs_to :topic
+  belongs_to :user
   has_many :comments, :as => :commentable
-  has_many :users, through: :user_posts
-  has_many :user_posts
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,3 +1,4 @@
 class Topic < ActiveRecord::Base
+  belongs_to :user
   has_many :posts, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,9 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
-  has_many :posts, through: :user_posts
   has_many :user_posts
+  has_many :posts, through: :user_posts
+  
 
   NICK_OPTIONS = [
     "His winning smile",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,8 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
-  has_many :user_posts
-  has_many :posts, through: :user_posts
+  has_many :posts
+  has_many :comments
   
 
   NICK_OPTIONS = [

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
   has_many :posts
-  has_many :comments
+  has_many :comments, :as => :commentable
   
 
   NICK_OPTIONS = [

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,10 +1,13 @@
-%h2 Forgot your password?
-= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-  = devise_error_messages!
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true
-  .actions
-    = f.submit "Send me reset password instructions"
-= render "devise/shared/links"
+.container
+  .row
+    .col-md-12.text-center
+      %h2 Forgot your password?
+      = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+        = devise_error_messages!
+        .field
+          = f.label :email
+          %br/
+          = f.email_field :email, autofocus: true
+        .actions
+          = f.submit "Send me reset password instructions"
+      = render "devise/shared/links"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,25 +1,28 @@
-%h2 Sign up
-= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-  = devise_error_messages!
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true
-  .field
-    = f.label "Favorite_thing_about_Nick"
-    %br/
-    =f.select :nick_thing, options_for_select(User::NICK_OPTIONS, f.object.nick_thing), include_blank: "--- Select ---"
-  .field
-    = f.label :password
-    - if @validatable
-      %em
-        (#{@minimum_password_length} characters minimum)
-    %br/
-    = f.password_field :password, autocomplete: "off"
-  .field
-    = f.label :password_confirmation
-    %br/
-    = f.password_field :password_confirmation, autocomplete: "off"
-  .actions
-    = f.submit "Sign up"
-= render "devise/shared/links"
+.container
+  .row
+    .col-md-12.text-center
+      %h2 Sign up
+      = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+        = devise_error_messages!
+        .field
+          = f.label :email
+          %br/
+          = f.email_field :email, autofocus: true
+        .field
+          = f.label "Favorite_thing_about_Nick"
+          %br/
+          =f.select :nick_thing, options_for_select(User::NICK_OPTIONS, f.object.nick_thing), include_blank: "--- Select ---"
+        .field
+          = f.label :password
+          - if @validatable
+            %em
+              (#{@minimum_password_length} characters minimum)
+          %br/
+          = f.password_field :password, autocomplete: "off"
+        .field
+          = f.label :password_confirmation
+          %br/
+          = f.password_field :password_confirmation, autocomplete: "off"
+        .actions
+          = f.submit "Sign up"
+      = render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,17 +1,20 @@
-%h2 Log in
-= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true
-  .field
-    = f.label :password
-    %br/
-    = f.password_field :password, autocomplete: "off"
-  - if devise_mapping.rememberable?
-    .field
-      = f.check_box :remember_me
-      = f.label :remember_me
-  .actions
-    = f.submit "Log in"
-= render "devise/shared/links"
+.container
+  .row
+    .col-md-12.text-center
+      %h2 Log in
+      = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+        .field
+          = f.label :email
+          %br/
+          = f.email_field :email, autofocus: true
+        .field
+          = f.label :password
+          %br/
+          = f.password_field :password, autocomplete: "off"
+        - if devise_mapping.rememberable?
+          .field
+            = f.check_box :remember_me
+            = f.label :remember_me
+        .actions
+          = f.submit "Log in"
+      = render "devise/shared/links"

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -39,7 +39,7 @@
           %br
           = comment.content
           %br
-          = comment.created_at.strftime("commented at %I:%M%p")
+          = comment.created_at.strftime("commented at %I:%M%p by #{current_user.email}")
           %br
           = link_to "Delete", destroy_comment_topic_post_path(@post, comment), method: :delete
 

--- a/app/views/topics/index.html.haml
+++ b/app/views/topics/index.html.haml
@@ -12,7 +12,7 @@
           %br
           = topic.initial_post
           %br
-          = topic.created_at.strftime("created at %I:%M%p")
+          = topic.created_at.strftime("created at %I:%M%p by #{current_user.email}")
           %br
           %br
 .container

--- a/app/views/topics/show.html.haml
+++ b/app/views/topics/show.html.haml
@@ -27,7 +27,7 @@
           %br
           = post.content
           %br
-          = post.created_at.strftime("posted at %I:%M%p")
+          = post.created_at.strftime("posted at %I:%M%p by #{current_user.email}")
           %br
           = link_to "Edit", edit_topic_post_path(@topic, post)
           |

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -8,11 +8,6 @@
 .container
   .row
     .col-md-12.text-center
-      %h3
-        =link_to "View Forum", topics_path
-.container
-  .row
-    .col-md-12.text-center
       = link_to 'Users:', users_path
       = User.count
       registered


### PR DESCRIPTION
just made some adjustments to our login, registration, and forgot password page. minor stuff, just centered them on the page. Having them off to the left of the page looked odd.

update

---

I went ahead and deleted "view forum" below the jumbotron. We already had a link to view the forum in the jumbotron. seemed redundant to have two.

update 2

---

boom. was able to add user_ids to comments and posts.
